### PR TITLE
circle: Contain isolated nightly build errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ commands:
 
   fmt:
     steps:
-      - run: rustup component add rustfmt || cargo install --git ssh://git@github.com/rust-lang/rustfmt.git --force rustfmt
+      - run: rustup component add rustfmt || cargo install --git ssh://git@github.com/rust-lang/rustfmt.git --force rustfmt-nightly
       - run: cargo fmt --verbose --all -- --check
 
   tarpaulin:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ commands:
 
   fmt:
     steps:
-      - run: rustup component add rustfmt-preview
+      - run: rustup component add rustfmt || cargo install --git ssh://git@github.com/rust-lang/rustfmt.git --force rustfmt
       - run: cargo fmt --verbose --all -- --check
 
   tarpaulin:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,9 +87,8 @@ workflows:
       - clippy
       - fmt
       - test:
-          requires: [check, clippy, fmt]
+          requires: [check]
       - coverage:
           requires: [test]
       - build:
           requires: [test]
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ workflows:
       - clippy
       - fmt
       - test:
-          requires: [check]
+          requires: [check, clippy, fmt]
       - coverage:
           requires: [test]
       - build:


### PR DESCRIPTION
While they will produce failing statuses, they should not completely halt builds.  This codebase should be able to be built and released with one-day-old clippy and fmt locally, if necessary.