### PR TITLE
index.css: Make bullet handling resilient to font-size changes

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -46,14 +46,16 @@ header > .tagline {
 	font-size: 1.5em;
 }
 
+header > .tagline > span.item.bigger + span.item:before { content: attr(data-separator) " "; }
 header > .tagline > span.item.bigger { font-size: 1.25em; }
 
-header > .tagline > span::after {
+header > .tagline > span.item::after {
 	font-size: var(--tagline-font-size);
 	content: " " attr(data-separator);
 }
 
-header > .tagline > span:last-child:after {
+header > .tagline > span:last-child:after,
+header > .tagline > span.bigger:after {
 	content: "";
 }
 


### PR DESCRIPTION
Since ::after automatically (and un-configurably) uses the font-size of its element, we end up with wonky bullets.  This commit instead takes all span.item's that come after a span.item.bigger and *prepends* the data-separator, and also removes bullets from span.item.bigger's.
