### PR TITLE
Add post navigation element

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -15,5 +15,11 @@ stylesheets:
 		{% endif %}
 	</header>
 
+	<nav>
+		<a href="{{ site.url }}">krye.io</a>
+		<span class="separator"></span>
+		<a href="{{ page.url }}">{{ page.title }}</a>
+	</nav>
+
 	{{ content }}
 </article>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -7,7 +7,6 @@ stylesheets:
 - '<link href="https://fonts.googleapis.com/css?family=Fira+Sans:200i&display=swap" rel="stylesheet">'
 - '<link rel="stylesheet" href="/post.css">'
 ---
-
 <article class="post">
 	<header>
 		<h1 class="title">{{ page.title }}</h1>

--- a/post.css
+++ b/post.css
@@ -7,6 +7,25 @@
 	--box-shadow-16: 0 16px 24px 2px rgba(0, 0, 0, .14), 0 6px 30px 5px rgba(0, 0, 0, .12), 0 8px 10px -5px rgba(0, 0, 0, .2);
 }
 
+
+article > nav {
+	color: #000000;
+	display: flex;
+	flex-wrap: nowrap;
+	justify-content: center;
+	font-size: 80%;
+}
+
+article > nav > span.separator:before {
+	user-select: none;
+	content: '\ff0f';
+}
+
+article > nav > a:last-child {
+	font-weight: 125%;
+	text-decoration: none;
+}
+
 article > header {
 	margin-top: 1in;
 	margin-bottom: 2em;


### PR DESCRIPTION
Closes #28.

Uses the `site.url`, `page.title`, and `page.url` variables to create a breadcrumb-style link to the chain.